### PR TITLE
Fix system DNS monitoring to exclude VPN networks

### DIFF
--- a/tunnel/src/main/java/net/pangolin/Pangolin/PacketTunnel/SystemDnsMonitor.java
+++ b/tunnel/src/main/java/net/pangolin/Pangolin/PacketTunnel/SystemDnsMonitor.java
@@ -93,7 +93,7 @@ public class SystemDnsMonitor {
 
         NetworkRequest request = new NetworkRequest.Builder()
                 .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                .removeTransportType(NetworkCapabilities.TRANSPORT_VPN)
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
                 .build();
 
         networkCallback = new ConnectivityManager.NetworkCallback() {


### PR DESCRIPTION
## Community Contribution License Agreement

By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

`removeTransportType(TRANSPORT_VPN)` removes a transport requirement from a `NetworkRequest`. It does not exclude VPN-backed networks.

This PR requires `NET_CAPABILITY_NOT_VPN` instead, so the system DNS monitor follows an underlying network rather than accidentally selecting the VPN it is helping to configure.

No other DNS or tunnel behavior is changed.

## How to test?

I ran:

- `./gradlew test assembleRelease`
- `git diff --check`

Both pass.

I also ran `./gradlew :tunnel:lintRelease`. It reports the same seven existing errors on a clean `dev` checkout, so this change does not add a new lint failure.

For a device check:

1. Connect Pangolin with system DNS monitoring enabled.
2. Switch between Wi-Fi and mobile data.
3. Confirm DNS continues to come from the active underlying network and the VPN network is not selected as its own system DNS source.
