### PR TITLE
Declare network state permission in the tunnel module

### DIFF
--- a/tunnel/src/main/AndroidManifest.xml
+++ b/tunnel/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application>
 	    <service
 	        android:name="net.pangolin.Pangolin.PacketTunnel.GoBackend$VpnService"


### PR DESCRIPTION
## Community Contribution License Agreement

By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

The tunnel module calls `ConnectivityManager` APIs that require `ACCESS_NETWORK_STATE`, but its own manifest does not declare that permission.

The app manifest already declares it, so this does not add a new permission to the shipped app. It makes the tunnel library's manifest match the APIs it uses and allows Android lint to verify those calls correctly.

## How to test?

I ran:

- `./gradlew test assembleRelease`
- `git diff --check`

Both pass.

I also compared `./gradlew :tunnel:lintRelease` before and after this change. The clean `dev` branch reports seven errors. With this manifest declaration it reports three, removing all four `ACCESS_NETWORK_STATE` findings. The three remaining `NewApi` errors are unchanged and outside this PR.
