### PR TITLE
Retry network settings until applied

### DIFF
--- a/tunnel/src/main/java/net/pangolin/Pangolin/PacketTunnel/GoBackend.java
+++ b/tunnel/src/main/java/net/pangolin/Pangolin/PacketTunnel/GoBackend.java
@@ -191,8 +191,9 @@ public final class GoBackend implements Backend {
                 final VpnService service = vpnService.getNow(null);
                 if (service != null) {
                     Log.d(TAG, "VpnService available, applying network settings");
-                    applyNetworkSettings(service, settings, tunnelName);
-                    Log.d(TAG, "Network settings application completed");
+                    boolean applied = applyNetworkSettings(service, settings, tunnelName);
+                    Log.d(TAG, "Network settings application completed: " + applied);
+                    return applied;
                 } else {
                     Log.w(TAG, "VpnService is null, cannot apply network settings");
                 }
@@ -200,7 +201,7 @@ public final class GoBackend implements Backend {
                 Log.e(TAG, "Failed to apply network settings", e);
             }
             Log.d(TAG, "=== Network settings callback completed ===");
-            return null;
+            return false;
         });
 
         networkSettingsPoller.startPolling();
@@ -296,10 +297,9 @@ public final class GoBackend implements Backend {
      * @param service The VPN service
      * @param settings The network settings to apply
      * @param tunnelName The name of the tunnel
-     * @return The new tunnel file descriptor, or null if failed
+     * @return true only when the interface was established and adopted by the Go backend
      */
-    @Nullable
-    public ParcelFileDescriptor applyNetworkSettings(VpnService service, NetworkSettings settings, String tunnelName) {
+    public boolean applyNetworkSettings(VpnService service, NetworkSettings settings, String tunnelName) {
         Log.d(TAG, "applyNetworkSettings called for tunnel: " + tunnelName);
         try {
             final VpnService.Builder builder = service.getBuilder();
@@ -327,11 +327,11 @@ public final class GoBackend implements Backend {
                 String result = addDevice(fd);
                 Log.d(TAG, "addDevice() returned: " + result);
 
-                if (result != null && result.startsWith("Error:")) {
+                if (result == null || result.startsWith("Error:")) {
                     Log.e(TAG, "Failed to add device to Go backend: " + result);
                     // The fd was detached, so we can't return it as a ParcelFileDescriptor anymore
                     // The Go side should handle cleanup if addDevice fails
-                    return null;
+                    return false;
                 }
                 Log.d(TAG, "Successfully hot-swapped tunnel interface to Go backend: " + result);
 
@@ -348,15 +348,14 @@ public final class GoBackend implements Backend {
                 }
                 currentTunFd = null; // Go backend now owns the fd
                 Log.d(TAG, "Network settings application completed successfully");
+                return true;
             } else {
                 Log.e(TAG, "builder.establish() returned null - failed to establish tunnel");
+                return false;
             }
-            // After detachFd(), the ParcelFileDescriptor is no longer valid
-            // Return null to indicate the fd has been transferred to Go backend
-            return null;
         } catch (Exception e) {
             Log.e(TAG, "Failed to apply network settings", e);
-            return null;
+            return false;
         }
     }
 

--- a/tunnel/src/main/java/net/pangolin/Pangolin/PacketTunnel/NetworkSettingsApplyTracker.java
+++ b/tunnel/src/main/java/net/pangolin/Pangolin/PacketTunnel/NetworkSettingsApplyTracker.java
@@ -1,0 +1,41 @@
+package net.pangolin.Pangolin.PacketTunnel;
+
+/**
+ * Tracks the newest network-settings version that was actually applied to Android's VPN.
+ * A failed attempt deliberately leaves the version pending so the poller retries it.
+ */
+final class NetworkSettingsApplyTracker {
+    private long lastAppliedVersion;
+    private long generation;
+
+    synchronized boolean shouldApply(long version) {
+        return version > lastAppliedVersion;
+    }
+
+    synchronized boolean recordSuccess(long attemptGeneration, long version) {
+        if (attemptGeneration != generation) {
+            return false;
+        }
+        if (version > lastAppliedVersion) {
+            lastAppliedVersion = version;
+        }
+        return true;
+    }
+
+    synchronized void recordFailure(long version) {
+        // Intentionally do not acknowledge the version.
+    }
+
+    synchronized long getLastAppliedVersion() {
+        return lastAppliedVersion;
+    }
+
+    synchronized long reset() {
+        lastAppliedVersion = 0;
+        return ++generation;
+    }
+
+    synchronized long getGeneration() {
+        return generation;
+    }
+}

--- a/tunnel/src/main/java/net/pangolin/Pangolin/PacketTunnel/NetworkSettingsPoller.java
+++ b/tunnel/src/main/java/net/pangolin/Pangolin/PacketTunnel/NetworkSettingsPoller.java
@@ -10,7 +10,6 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
-import android.os.ParcelFileDescriptor;
 import android.os.Process;
 import android.system.OsConstants;
 import android.util.Log;
@@ -21,7 +20,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
 import androidx.annotation.Nullable;
 
@@ -38,7 +36,7 @@ public class NetworkSettingsPoller {
     private static final int MAX_CONSECUTIVE_ERRORS = 10;
 
     private final GoBackend goBackend;
-    private final AtomicLong lastSettingsVersion = new AtomicLong(0);
+    private final NetworkSettingsApplyTracker applyTracker = new NetworkSettingsApplyTracker();
     private final AtomicBoolean isPolling = new AtomicBoolean(false);
     private final AtomicBoolean isPaused = new AtomicBoolean(false);
     private final Object lock = new Object();
@@ -55,9 +53,9 @@ public class NetworkSettingsPoller {
         /**
          * Called when network settings have been updated.
          * @param settings The new network settings
-         * @return ParcelFileDescriptor for the new tunnel, or null if rebuild not needed
+         * @return true only when Android accepted and the Go backend adopted the new interface
          */
-        @Nullable ParcelFileDescriptor onNetworkSettingsUpdated(NetworkSettings settings);
+        boolean onNetworkSettingsUpdated(NetworkSettings settings);
     }
 
     /**
@@ -88,7 +86,7 @@ public class NetworkSettingsPoller {
             }
 
             Log.d(TAG, "Starting network settings polling");
-            lastSettingsVersion.set(0);
+            applyTracker.reset();
             consecutiveErrors = 0;
             isPaused.set(false);
 
@@ -168,7 +166,7 @@ public class NetworkSettingsPoller {
                 handlerThread = null;
             }
 
-            lastSettingsVersion.set(0);
+            applyTracker.reset();
             consecutiveErrors = 0;
         }
     }
@@ -234,45 +232,40 @@ public class NetworkSettingsPoller {
     };
 
     private void checkForSettingsUpdate() {
-        try {
-            long currentVersion = goBackend.getNetworkSettingsVersionNumber();
-            long lastVersion = lastSettingsVersion.get();
+        long attemptGeneration = applyTracker.getGeneration();
+        long currentVersion = goBackend.getNetworkSettingsVersionNumber();
+        long lastVersion = applyTracker.getLastAppliedVersion();
 
-            // Log.v(TAG, "Polling: currentVersion=" + currentVersion + ", lastVersion=" + lastVersion + ", isPolling=" + isPolling.get());
+        if (applyTracker.shouldApply(currentVersion)) {
+            Log.d(TAG, "Network settings version pending: " + lastVersion + " -> " + currentVersion);
 
-            if (currentVersion > lastVersion) {
-                Log.d(TAG, "Network settings version changed: " + lastVersion + " -> " + currentVersion);
-
-                String settingsJson = goBackend.getNetworkSettingsJSON();
-                Log.d(TAG, "Retrieved settings JSON (length=" + (settingsJson != null ? settingsJson.length() : 0) + ")");
-                
-                if (settingsJson != null && !settingsJson.isEmpty() && !settingsJson.equals("{}")) {
-                    try {
-                        NetworkSettings settings = NetworkSettings.fromJson(settingsJson);
-                        Log.d(TAG, "Parsed network settings, invoking callback (callback=" + (callback != null ? "present" : "null") + ")");
-                        
-                        if (callback != null) {
-                            callback.onNetworkSettingsUpdated(settings);
-                            Log.d(TAG, "Callback invoked successfully");
-                        } else {
-                            Log.w(TAG, "Callback is null, cannot apply settings");
-                        }
-                        
-                        // Only update the version after successfully applying settings
-                        lastSettingsVersion.set(currentVersion);
-                        Log.d(TAG, "Updated lastSettingsVersion to " + currentVersion);
-                    } catch (JSONException e) {
-                        Log.e(TAG, "Failed to parse network settings JSON", e);
-                    }
-                } else {
-                    Log.d(TAG, "Skipping empty or null settings JSON, will retry on next poll");
-                }
-            } else if (currentVersion < lastVersion) {
-                Log.w(TAG, "Version went backwards! currentVersion=" + currentVersion + ", lastVersion=" + lastVersion + ". Resetting.");
-                lastSettingsVersion.set(currentVersion);
+            String settingsJson = goBackend.getNetworkSettingsJSON();
+            if (settingsJson == null || settingsJson.isEmpty() || settingsJson.equals("{}")) {
+                Log.d(TAG, "Skipping empty network settings; version remains pending");
+                return;
             }
-        } catch (Exception e) {
-            Log.e(TAG, "Error checking for settings update", e);
+
+            final NetworkSettings settings;
+            try {
+                settings = NetworkSettings.fromJson(settingsJson);
+            } catch (JSONException e) {
+                Log.e(TAG, "Failed to parse network settings; version remains pending", e);
+                return;
+            }
+            boolean applied = callback != null && callback.onNetworkSettingsUpdated(settings);
+            if (applied) {
+                if (applyTracker.recordSuccess(attemptGeneration, currentVersion)) {
+                    Log.d(TAG, "Acknowledged applied network settings version " + currentVersion);
+                } else {
+                    Log.d(TAG, "Ignored network settings acknowledgement from an older polling session");
+                }
+            } else {
+                applyTracker.recordFailure(currentVersion);
+                Log.w(TAG, "Network settings version " + currentVersion + " was not applied; retrying");
+            }
+        } else if (currentVersion < lastVersion) {
+            Log.w(TAG, "Network settings version went backwards; resetting acknowledgement state");
+            applyTracker.reset();
         }
     }
 

--- a/tunnel/src/test/java/net/pangolin/Pangolin/PacketTunnel/NetworkSettingsApplyTrackerTest.java
+++ b/tunnel/src/test/java/net/pangolin/Pangolin/PacketTunnel/NetworkSettingsApplyTrackerTest.java
@@ -1,0 +1,51 @@
+package net.pangolin.Pangolin.PacketTunnel;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class NetworkSettingsApplyTrackerTest {
+    @Test
+    public void failedApplyLeavesVersionPendingForRetry() {
+        NetworkSettingsApplyTracker tracker = new NetworkSettingsApplyTracker();
+
+        assertTrue(tracker.shouldApply(1));
+        tracker.recordFailure(1);
+
+        assertTrue(tracker.shouldApply(1));
+    }
+
+    @Test
+    public void successfulApplyAcknowledgesVersion() {
+        NetworkSettingsApplyTracker tracker = new NetworkSettingsApplyTracker();
+        long generation = tracker.getGeneration();
+
+        tracker.recordSuccess(generation, 3);
+
+        assertFalse(tracker.shouldApply(3));
+        assertFalse(tracker.shouldApply(2));
+        assertTrue(tracker.shouldApply(4));
+    }
+
+    @Test
+    public void resetMakesVersionsPendingAgain() {
+        NetworkSettingsApplyTracker tracker = new NetworkSettingsApplyTracker();
+        long generation = tracker.getGeneration();
+        tracker.recordSuccess(generation, 5);
+
+        tracker.reset();
+
+        assertTrue(tracker.shouldApply(1));
+    }
+
+    @Test
+    public void staleApplyCannotAcknowledgeNewPollingSession() {
+        NetworkSettingsApplyTracker tracker = new NetworkSettingsApplyTracker();
+        long oldGeneration = tracker.getGeneration();
+        tracker.reset();
+
+        assertFalse(tracker.recordSuccess(oldGeneration, 7));
+        assertTrue(tracker.shouldApply(7));
+    }
+}

--- a/tunnel/tools/libpangolin-go/api-android.go
+++ b/tunnel/tools/libpangolin-go/api-android.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"syscall"
 
 	olmpkg "github.com/fosrl/olm/olm"
 )
@@ -169,6 +170,13 @@ func startTunnel(fd C.int, configJSON *C.char) *C.char {
 
 //export addDevice
 func addDevice(fd C.int) *C.char {
+	fdOwnedByOlm := false
+	defer func() {
+		if !fdOwnedByOlm {
+			_ = syscall.Close(int(fd))
+		}
+	}()
+
 	if olmInstance == nil {
 		appLogger.Error("OLM instance not initialized")
 		return C.CString("Error: OLM instance not initialized")
@@ -179,6 +187,7 @@ func addDevice(fd C.int) *C.char {
 		appLogger.Error("Failed to add device: %v", err)
 		return C.CString(fmt.Sprintf("Error: Failed to add device: %v", err))
 	}
+	fdOwnedByOlm = true
 	return C.CString("Device added successfully")
 }
 


### PR DESCRIPTION
## Community Contribution License Agreement

By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

This addresses the failure mode described in #28. Fixes #28 

The network settings poller currently advances its version after invoking the callback, even when the VPN service is unavailable or applying the replacement interface fails. Once that happens, the same settings version is treated as handled and is not tried again until the app is restarted.

This PR acknowledges a version only after Android establishes the replacement VPN interface and the Go backend adopts it. Failed attempts and malformed settings stay pending for the next polling cycle. A polling generation guard prevents a callback from an older session from acknowledging settings after a stop and restart. The native bridge also closes the transferred file descriptor when adoption fails, so retries do not leak descriptors.

The contents of the network settings, routes, and DNS configuration are unchanged.

## How to test?

I added unit coverage for the acknowledgement behavior:

- a failed apply keeps the version pending;
- a successful apply acknowledges it;
- a reset makes the version pending again;
- a callback from an older polling session cannot acknowledge the new session.

I also temporarily restored the old failure behavior and confirmed the new regression test fails, then restored the fix and confirmed it passes.

I ran:

- `./gradlew test assembleRelease`
- `git diff --check`

Both pass. The release build compiled the native tunnel library for arm64-v8a, armeabi-v7a, x86, and x86_64.

I also ran `./gradlew :tunnel:lintRelease`. It reports the same seven existing errors on a clean `dev` checkout, so this change does not add a new lint failure.

I have not reproduced the exact GrapheneOS scenario from #28 on a physical device.
